### PR TITLE
Load action names in flight mode

### DIFF
--- a/Source/DMModuleScienceAnimate.cs
+++ b/Source/DMModuleScienceAnimate.cs
@@ -256,6 +256,10 @@ namespace DMagic
 			Events["DeployExperiment"].guiActiveUnfocused = externalDeploy;
 			Events["DeployExperiment"].externalToEVAOnly = externalDeploy;
 			Events["DeployExperiment"].unfocusedRange = interactionRange;
+            Actions["deployAction"].guiName = startEventGUIName;
+            Actions["retractAction"].guiName = endEventGUIName;
+            Actions["toggleAction"].guiName = toggleEventGUIName;
+            Actions["DeployAction"].guiName = experimentActionName;
 			if (!primary) {
 				primaryList = this.part.FindModulesImplementing<DMModuleScienceAnimate>();
 				if (primaryList.Count > 0) {


### PR DESCRIPTION
Add code in flight mode so it loads the action names from the part.cfg
file.

Without this the action names the player sees in the editor and flight
mode differs

The player requires a mod to see the action name in flight mode, such as my Action Groups mod. Without this, a player just see the default "Deploy" as set by the KSPFIeld default. 

This does not affect functionality of your mod in any way, it is purely a UI thing.
