### PR TITLE
Don't apply CTT fixes if RP-0 is loaded.

### DIFF
--- a/GameData/DMagic Orbital Science/Resources/DMagicCommunityTechTree.cfg
+++ b/GameData/DMagic Orbital Science/Resources/DMagicCommunityTechTree.cfg
@@ -4,213 +4,213 @@
 //Part costs and experiment values are also adjusted
 
 
-@PART[dmmagBoom]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmmagBoom]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@entryCost = 5000
 	@cost = 3000
 }
 
-@PART[rpwsAnt]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[rpwsAnt]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = spaceExploration
 	@entryCost = 8000
 	@cost = 4000
 }
 
-@PART[dmscope]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmscope]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = orbitalSurveys
 	@entryCost = 12500
 	@cost = 8000
 }
 
-@PART[dmImagingPlatform]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmImagingPlatform]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = advSurveys
 	@entryCost = 15000
 	@cost = 11000
 }
 
-@PART[dmSoilMoisture]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmSoilMoisture]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = electronics
 	@entryCost = 24000
 	@cost = 12000
 }
 
-@PART[dmSolarCollector]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmSolarCollector]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = longTermScienceTech
 	@entryCost = 30000
 	@cost = 20000
 }
 
-@PART[dmsurfacelaser]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmsurfacelaser]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = advExploration
 	@entryCost = 15000
 	@cost = 8000
 }
 
-@PART[dmbioDrill]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmbioDrill]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = fieldScience
 	@entryCost = 18000
 	@cost = 9000
 }
 
-@PART[dmAnomScanner]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmAnomScanner]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = experimentalScience
 	@entryCost = 39000
 	@cost = 25000
 }
 
-@PART[dmDAN]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmDAN]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = advScienceTech
 	@entryCost = 19000
 	@cost = 10000
 }
 
-@PART[dmXRay]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmXRay]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
     @TechRequired = specializedScienceTech
 	@entryCost = 24000
 	@cost = 12000
 }
 
-@PART[dmRoverGoo]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmRoverGoo]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@entryCost = 50000
 	@cost = 32000
 }
 
-@PART[dmRoverMat]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager]
+@PART[dmRoverMat]:FOR[DMagic]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@entryCost = 65000
 	@cost = 40000
 }
 
-@PART[dmUSMat]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSMat]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = aerodynamicSystems
 	@entryCost = 5000
 	@cost = 3000
 }
 
-@PART[dmUSGoo]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSGoo]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = generalConstruction
 	@entryCost = 4000
 	@cost = 2000
 }
 
-@PART[dmUSMagBoom]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSMagBoom]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = advConstruction
 	@entryCost = 9000
 	@cost = 5500
 }
 
-@PART[USRPWS]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[USRPWS]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = actuators
 	@entryCost = 13000
 	@cost = 6500
 }
 
-@PART[dmUSScope]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSScope]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = precisionEngineering
 	@entryCost = 15000
 	@cost = 10000
 }
 
-@PART[dmUSSolarParticles]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSSolarParticles]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = advAerospaceComposites
 	@entryCost = 38000
 	@cost = 24000
 }
 
-@PART[dmUSPresTemp]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSPresTemp]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = subsonicFlight
 	@entryCost = 11000
 	@cost = 8000
 }
 
-@PART[dmUSAccGrav]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSAccGrav]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = advUnmanned
 	@entryCost = 29000
 	@cost = 18000
 }
 
-@PART[dmUSAtmosSense]:NEEDS[CommunityTechTree,TechManager]:AFTER[DMagic]
+@PART[dmUSAtmosSense]:NEEDS[CommunityTechTree,TechManager,!RP-0]:AFTER[DMagic]
 {
     @TechRequired = aerospaceTech
 	@entryCost = 18000
 	@cost = 7500
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[magScan]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[magScan]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 4
 	@scienceCap = 4
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[rpwsScan]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[rpwsScan]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 6
 	@scienceCap = 6
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[scopeScan]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[scopeScan]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@dataScale = 4
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmImagingPlatform]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[dmImagingPlatform]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 7
 	@scienceCap = 7
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmNAlbedoScan]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[dmNAlbedoScan]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 7
 	@scienceCap = 7
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmXRayDiffract]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[dmXRayDiffract]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 8
 	@scienceCap = 8
 	@dataScale = 4
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSolarParticles]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSolarParticles]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 10
 	@scienceCap = 14
 	@dataScale = 3
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSoilMoisture]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSoilMoisture]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 8
 	@scienceCap = 8
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmbiodrillscan]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[dmbiodrillscan]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 5
 	@scienceCap = 8
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[AnomalyScan]]:NEEDS[CommunityTechTree,TechManager]
+@EXPERIMENT_DEFINITION[*]:HAS[#id[AnomalyScan]]:NEEDS[CommunityTechTree,TechManager,!RP-0]
 {
 	@baseValue = 14
 	@scienceCap = 14


### PR DESCRIPTION
RP-0, a career mode for the RealismOverhaul universe with support for DMagic
Orbital Science, uses the CTT, but sets its own tech positions. While it would
be great if we could just do an `:AFTER[DMagic]` to do this, we can't do that
on MM stanzas that don't have a `:FOR[DMagic]` attached to them. Because MM
doens't yet play nicely with having both `:FOR` and `:AFTER` tags, simplying
adding a `:FOR` doens't guarantee everyone gets the behaviour they want; plus
we can't exactly have `:FOR[DMagic]:AFTER[DMagic]`.

Consequetly, I've adjusted `DMagicCommunityTechTree.cfg` to only apply its
changes if RP-0 is not loaded. If you prefer we could instead search for a
special token, rather than RP-0 specifically. For example:
`:NEEDS[!CTT_Config]`. RP-0 and other career mods can simply define
`CTT_Config` if they wish to use the CTT, but do their own part placement
inside it.

Thanks again for an awesome mod!

~ Paul
