### PR TITLE
Tweak stock sat contracts to accept Orbital-Science parts

### DIFF
--- a/GameData/DMagic Orbital Science/Rover Science/RoverGoo/RoverGoo.cfg
+++ b/GameData/DMagic Orbital Science/Rover Science/RoverGoo/RoverGoo.cfg
@@ -81,3 +81,14 @@ MODULE
 	bioMask = 3
 	}
 }
+
+@Contracts:FOR[DMagic]
+{
+	@Satellite
+	{
+		@PART_REQUEST:HAS[#Part[GooExperiment]]
+		{
+			Part = dmRoverGoo
+		}
+	}
+}

--- a/GameData/DMagic Orbital Science/Rover Science/RoverMat/RoverMat.cfg
+++ b/GameData/DMagic Orbital Science/Rover Science/RoverMat/RoverMat.cfg
@@ -81,3 +81,14 @@ MODULE
 	bioMask = 3
 	}
 }
+
+@Contracts:FOR[DMagic]
+{
+	@Satellite
+	{
+		@PART_REQUEST:HAS[#Part[science_module]]
+		{
+			Part = dmRoverMat
+		}
+	}
+}

--- a/GameData/DMagic Orbital Science/Universal Storage/US GooMat/USGoo.cfg
+++ b/GameData/DMagic Orbital Science/Universal Storage/US GooMat/USGoo.cfg
@@ -96,3 +96,14 @@ MODULE
 	@TechRequired = survivability
 	@category = Science
 }
+
+@Contracts:FOR[DMagic]:NEEDS[UniversalStorage]
+{
+	@Satellite
+	{
+		@PART_REQUEST:HAS[#Part[GooExperiment]]
+		{
+			Part = dmUSGoo
+		}
+	}
+}

--- a/GameData/DMagic Orbital Science/Universal Storage/US GooMat/USMat.cfg
+++ b/GameData/DMagic Orbital Science/Universal Storage/US GooMat/USMat.cfg
@@ -96,3 +96,14 @@ MODULE
 	@TechRequired = scienceTech
 	@category = Science
 }
+
+@Contracts:FOR[DMagic]:NEEDS[UniversalStorage]
+{
+	@Satellite
+	{
+		@PART_REQUEST:HAS[#Part[science_module]]
+		{
+			Part = dmUSMat
+		}
+	}
+}

--- a/GameData/DMagic Orbital Science/Universal Storage/US Stock/ACCGRAV.cfg
+++ b/GameData/DMagic Orbital Science/Universal Storage/US Stock/ACCGRAV.cfg
@@ -163,3 +163,25 @@ MODULE
 	@TechRequired = advScienceTech
 	@category = Science
 }
+
+@Contracts:FOR[DMagic]:NEEDS[UniversalStorage]
+{
+	@Satellite
+	{
+		@PART_REQUEST:HAS[#Part[sensorGravimeter]]
+		{
+			Part = dmUSAccGrav
+		}
+	}
+}
+
+@Contracts:FOR[DMagic]:NEEDS[UniversalStorage]
+{
+	@Satellite
+	{
+		@PART_REQUEST:HAS[#Part[sensorAccelerometer]]
+		{
+			Part = dmUSAccGrav
+		}
+	}
+}

--- a/GameData/DMagic Orbital Science/Universal Storage/US Stock/PRESTEMP.cfg
+++ b/GameData/DMagic Orbital Science/Universal Storage/US Stock/PRESTEMP.cfg
@@ -154,3 +154,14 @@ MODULE
 	@TechRequired = advExploration
 	@category = Science
 }
+
+@Contracts:FOR[DMagic]:NEEDS[UniversalStorage]
+{
+	@Satellite
+	{
+		@PART_REQUEST:HAS[#Part[sensorThermometer]]
+		{
+			Part = dmUSPresTemp
+		}
+	}
+}


### PR DESCRIPTION
I enjoy the orbital science mod very much, but one thing annoyed me every time: The satellite contracts would not accept orbital-science variants of stock parts (e.g. a contract requesting a thermometer would not accept the combined Universal Storage thermometer / barometer).

To solve this problem, this pull requests adds module manager configs, so that the Rover / Universal Storage variants of stock parts are accepted for stock satellite contracts, e.g. if a contract requests "Have a mystery goo unit on the satellite" the "Univ. Storage - Mystery Goo Containment" or the "Micro Goo Containment Pod" will also be accepted instead of the stock "Mystery Goo™ Containment Unit".

The same is true for materials bay, thermometer, gravioli detector and seismic accelerometer .