### PR TITLE
Update for new ScienceExponents

### DIFF
--- a/GameData/DMagicOrbitalScience/Resources/DMagicTweakScale.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMagicTweakScale.cfg
@@ -27,45 +27,45 @@ TWEAKSCALEEXPONENTS
 
 @PART[dmImagingPlatform]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmmagBoom]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[rpwsAnt]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmscope]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmSoilMoisture]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = stack
 		defaultScale = 0.625
 		scaleFactors = 0.625, 1.25
@@ -75,9 +75,9 @@ TWEAKSCALEEXPONENTS
 
 @PART[dmSolarCollector]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = stack
 		defaultScale = 0.625
 		scaleFactors = 0.625, 1.25
@@ -87,9 +87,9 @@ TWEAKSCALEEXPONENTS
 
 @PART[dmSIGINT]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = stack
 		defaultScale = 2.5
 		scaleFactors = 1.25, 2.5, 3.75
@@ -99,9 +99,9 @@ TWEAKSCALEEXPONENTS
 
 @PART[dmReconSmall]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = stack
 		defaultScale = 1.25
 		scaleFactors = 0.625, 1.25, 2.5
@@ -111,9 +111,9 @@ TWEAKSCALEEXPONENTS
 
 @PART[dmReconLarge]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = stack
 		defaultScale = 2.5
 		scaleFactors = 1.25, 2.5, 3.75
@@ -123,108 +123,108 @@ TWEAKSCALEEXPONENTS
 
 @PART[dmAnomScanner]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmbioDrill]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmDAN]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmsurfacelaser]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmRoverGoo]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmRoverMat]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmXRay]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmGoreSat]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmASERT]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmSeismicHammer]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmSeismicPod]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }
 
 @PART[dmBathymetry]:FOR[DMagic]:NEEDS[Scale]
 {
-	MODULE
+	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
+	%MODULE[TweakScale]
 	{
-		name = TweakScale
 		type = DMagicOrbitalScienceScale
 	}
 }


### PR DESCRIPTION
Since version 2.2.7.1 TweakScale added an exponent for science parts which makes them more expensive when they're scaled down. Previously TweakScale was a cheat for making science parts cheaper and less weighty.