### PR TITLE
Module Manager 3.0.1 compatibility

### DIFF
--- a/GameData/DMagicOrbitalScience/Resources/DMagicCommunityTechTree.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMagicCommunityTechTree.cfg
@@ -231,76 +231,76 @@
 	@cost = 9500
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[magScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[magScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 4
 	@scienceCap = 4
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[rpwsScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[rpwsScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 6
 	@scienceCap = 6
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[scopeScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[scopeScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 6
 	@scienceCap = 6
 	@dataScale = 4
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmImagingPlatform]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmImagingPlatform]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 7
 	@scienceCap = 7
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmNAlbedoScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmNAlbedoScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 7
 	@scienceCap = 7
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmXRayDiffract]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmXRayDiffract]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 8
 	@scienceCap = 8
 	@dataScale = 4
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSolarParticles]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmSolarParticles]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 10
 	@scienceCap = 14
 	@dataScale = 3
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSoilMoisture]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmSoilMoisture]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 8
 	@scienceCap = 8
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmAsteroidScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmAsteroidScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 7
 	@scienceCap = 7
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmRadiometerScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmRadiometerScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 10
 	@scienceCap = 10
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmbiodrillscan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[dmbiodrillscan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 5
 	@scienceCap = 8
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[AnomalyScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@EXPERIMENT_DEFINITION:HAS[#id[AnomalyScan]]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@baseValue = 14
 	@scienceCap = 14

--- a/GameData/DMagicOrbitalScience/Resources/NewScienceDefs.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/NewScienceDefs.cfg
@@ -1,4 +1,4 @@
-@EXPERIMENT_DEFINITION[*]:HAS[#id[seismicScan]]
+@EXPERIMENT_DEFINITION:HAS[#id[seismicScan]]
 {
 	%RESULTS
 	{
@@ -15,7 +15,7 @@
 	}
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[gravityScan]]
+@EXPERIMENT_DEFINITION:HAS[#id[gravityScan]]
 {
 	%RESULTS
 	{
@@ -30,7 +30,7 @@
 	}
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[mysteryGoo]]
+@EXPERIMENT_DEFINITION:HAS[#id[mysteryGoo]]
 {
 	%RESULTS
 	{


### PR DESCRIPTION
[*] selector was originaly meant for named nodes and is now enforced in the latest MM, so it brake changes for experiments identified by id only. The solution is to remove this selector.