### PR TITLE
Fix experiments for universal storage

### DIFF
--- a/Source/DMUtils.cs
+++ b/Source/DMUtils.cs
@@ -54,6 +54,17 @@ namespace DMagic
 		private static Regex closeBraket = new Regex(@"(?<=\{\d+:?\w?\d?)\]");
 		private static Regex newLines = new Regex(@"\\n");
 
+		internal static Animation GetAnimation(Part part, String name)
+		{
+			if (string.IsNullOrEmpty(name)) return null;
+			Animation[] animators = part.FindModelAnimators(name);
+			if(animators.Length == 0) {
+				Debug.LogWarning("[DMOS] No animation named '" + name + "' found for part " + part.name);
+				return null;
+			}
+			return animators[0];
+		}
+
 		internal static float fixSubjectVal(ExperimentSituations s, float f, CelestialBody body)
 		{
 			float subV = f;

--- a/Source/Part Modules/DMAnomalyScanner.cs
+++ b/Source/Part Modules/DMAnomalyScanner.cs
@@ -56,8 +56,9 @@ namespace DMagic.Part_Modules
 		public override void OnStart(PartModule.StartState state)
 		{
 			base.OnStart(state);
-			animSecondary = part.FindModelAnimators(camAnimate)[0];
-			animSecondary = part.FindModelAnimators(foundAnimate)[0];
+			// erm... animSecondary was assigned twice, no matter what
+			animSecondary = DMUtils.GetAnimation(part, camAnimate);
+			if (animSecondary == null) animSecondary = DMUtils.GetAnimation(part, foundAnimate);
 			if (IsDeployed)
 				fullyDeployed = true;
 			base.Events["CollectDataExternalEvent"].active = false;

--- a/Source/Part Modules/DMAsteroidScanner.cs
+++ b/Source/Part Modules/DMAsteroidScanner.cs
@@ -118,14 +118,10 @@ namespace DMagic.Part_Modules
 
 		public override void OnStart(PartModule.StartState state)
 		{
-			if (!string.IsNullOrEmpty(animationName))
-				Anim = part.FindModelAnimators(animationName)[0];
-			if (!string.IsNullOrEmpty(greenLight))
-				IndicatorAnim1 = part.FindModelAnimators(greenLight)[0];
-			if (!string.IsNullOrEmpty(yellowLight))
-				IndicatorAnim2 = part.FindModelAnimators(yellowLight)[0];
-			if (USScience && !string.IsNullOrEmpty(USBayAnimation))
-				USAnim = part.FindModelAnimators(USBayAnimation)[0];
+			Anim = DMUtils.GetAnimation(part, animationName);
+			IndicatorAnim1 = DMUtils.GetAnimation(part, greenLight);
+			IndicatorAnim2 = DMUtils.GetAnimation(part, yellowLight);
+			if (USScience) USAnim = DMUtils.GetAnimation(part, USBayAnimation);
 			if (!string.IsNullOrEmpty(experimentID))
 				exp = ResearchAndDevelopment.GetExperiment(experimentID);
 			if (IsDeployed)

--- a/Source/Part Modules/DMBasicScienceModule.cs
+++ b/Source/Part Modules/DMBasicScienceModule.cs
@@ -138,8 +138,7 @@ namespace DMagic.Part_Modules
 
 		public override void OnStart(PartModule.StartState state)
 		{
-			if (!string.IsNullOrEmpty(animationName))
-				anim = part.FindModelAnimators(animationName)[0];
+			anim = DMUtils.GetAnimation(part, animationName);
 
 			if (state == StartState.Editor)
 				editorSetup();

--- a/Source/Part Modules/DMBioDrill.cs
+++ b/Source/Part Modules/DMBioDrill.cs
@@ -43,8 +43,7 @@ namespace DMagic.Part_Modules
 		public override void OnStart(PartModule.StartState state)
 		{
 			base.OnStart(state);
-			if (!string.IsNullOrEmpty(verticalDrill))
-				anim = part.FindModelAnimators(verticalDrill)[0];
+			anim = DMUtils.GetAnimation(part, verticalDrill);
 		}
 
 		public override bool canConduct()

--- a/Source/Part Modules/DMModuleScienceAnimate.cs
+++ b/Source/Part Modules/DMModuleScienceAnimate.cs
@@ -178,26 +178,26 @@ namespace DMagic.Part_Modules
 
 		public override void OnStart(StartState state)
 		{
-			if (!string.IsNullOrEmpty(animationName))
-				anim = part.FindModelAnimators(animationName)[0];
+			anim = DMUtils.GetAnimation(part, animationName);
+
 			if (!string.IsNullOrEmpty(sampleAnim))
 			{
-				anim2 = part.FindModelAnimators(sampleAnim)[0];
+				anim2 = DMUtils.GetAnimation(part, sampleAnim);
 				if (experimentLimit != 0)
 					secondaryAnimator(sampleAnim, 0f, experimentNumber * (1f / experimentLimit), 1f);
 			}
 			if (!string.IsNullOrEmpty(indicatorAnim))
 			{
-				anim2 = part.FindModelAnimators(indicatorAnim)[0];
+				anim2 = DMUtils.GetAnimation(part, indicatorAnim);
 				if (experimentLimit != 0)
 					secondaryAnimator(indicatorAnim, 0f, experimentNumber * (1f / experimentLimit), 1f);
 			}
 			if (!string.IsNullOrEmpty(sampleEmptyAnim))
-				anim2 = part.FindModelAnimators(sampleEmptyAnim)[0];
+				anim2 = DMUtils.GetAnimation(part, sampleEmptyAnim);
 			if (!string.IsNullOrEmpty(looperAnimation))
-				anim3 = part.FindModelAnimators(looperAnimation)[0];
+				anim3 = DMUtils.GetAnimation(part, looperAnimation);
 			if (!string.IsNullOrEmpty(bayAnimation))
-				anim4 = part.FindModelAnimators(bayAnimation)[0];
+				anim4 = DMUtils.GetAnimation(part, bayAnimation);
 			if (state == StartState.Editor) editorSetup();
 			else
 			{
@@ -367,7 +367,7 @@ namespace DMagic.Part_Modules
 			}
 			if (USStock)
 				enviroList = this.part.FindModulesImplementing<DMEnviroSensor>();
-			if (waitForAnimationTime == -1 && animSpeed != 0)
+			if (waitForAnimationTime == -1 && animSpeed != 0 && anim != null)
 				waitForAnimationTime = anim[animationName].length / animSpeed;
 			if (!string.IsNullOrEmpty(experimentID))
 			{
@@ -604,12 +604,14 @@ namespace DMagic.Part_Modules
 		{
 			if (experimentLimit > 1)
 			{
-				if (!string.IsNullOrEmpty(sampleEmptyAnim))
-					secondaryAnimator(sampleEmptyAnim, animSpeed, 1f - (experimentNumber * (1f / experimentLimit)), experimentNumber * (anim2[sampleEmptyAnim].length / experimentLimit));
-				else if (!string.IsNullOrEmpty(sampleAnim))
-					secondaryAnimator(sampleAnim, -1f * animSpeed, experimentNumber * (1f / experimentLimit), experimentNumber * (anim2[sampleAnim].length / experimentLimit));
-				if (!string.IsNullOrEmpty(indicatorAnim))
-					secondaryAnimator(indicatorAnim, -1f * animSpeed, experimentNumber * (1f / experimentLimit), experimentNumber * (anim2[indicatorAnim].length / experimentLimit));
+				if(anim2 != null) {
+					if (!string.IsNullOrEmpty(sampleEmptyAnim))
+						secondaryAnimator(sampleEmptyAnim, animSpeed, 1f - (experimentNumber * (1f / experimentLimit)), experimentNumber * (anim2[sampleEmptyAnim].length / experimentLimit));
+					else if (!string.IsNullOrEmpty(sampleAnim))
+						secondaryAnimator(sampleAnim, -1f * animSpeed, experimentNumber * (1f / experimentLimit), experimentNumber * (anim2[sampleAnim].length / experimentLimit));
+					if (!string.IsNullOrEmpty(indicatorAnim))
+						secondaryAnimator(indicatorAnim, -1f * animSpeed, experimentNumber * (1f / experimentLimit), experimentNumber * (anim2[indicatorAnim].length / experimentLimit));
+				}
 
 				foreach (ScienceData data in storedScienceReports)
 					experimentNumber--;
@@ -1014,6 +1016,7 @@ namespace DMagic.Part_Modules
 			}
 			else if ((sitMask & (int)getSituation()) == 0)
 			{
+				MonoBehaviour.print("[XXX 1] sitMask " + sitMask + " situation " + (int)getSituation());
 				failMessage = customFailMessage;
 				return false;
 			}
@@ -1025,6 +1028,7 @@ namespace DMagic.Part_Modules
 			}
 			else if (scienceExp.requireAtmosphere && !vessel.mainBody.atmosphere)
 			{
+				MonoBehaviour.print("[XXX 2] reqatmo " + scienceExp.requireAtmosphere + " inatmo " + vessel.mainBody.atmosphere);
 				failMessage = customFailMessage;
 				return false;
 			}
@@ -1198,11 +1202,11 @@ namespace DMagic.Part_Modules
 			{
 				if (experimentLimit != 0)
 				{
-					if (!string.IsNullOrEmpty(sampleEmptyAnim))
+					if (!string.IsNullOrEmpty(sampleEmptyAnim) && anim2 != null)
 						secondaryAnimator(sampleEmptyAnim, animSpeed, 1f - (experimentNumber * (1f / experimentLimit)), anim2[sampleEmptyAnim].length / experimentLimit);
-					else if (!string.IsNullOrEmpty(sampleAnim))
+					else if (!string.IsNullOrEmpty(sampleAnim) && anim2 != null)
 						secondaryAnimator(sampleAnim, -1f * animSpeed, experimentNumber * (1f / experimentLimit), anim2[sampleAnim].length / experimentLimit);
-					if (!string.IsNullOrEmpty(indicatorAnim))
+					if (!string.IsNullOrEmpty(indicatorAnim) && anim != null)
 						secondaryAnimator(indicatorAnim, -1f * animSpeed, experimentNumber * (1f / experimentLimit), anim[indicatorAnim].length / experimentLimit);
 				}
 				storedScienceReports.Remove(data);
@@ -1269,7 +1273,7 @@ namespace DMagic.Part_Modules
 			}
 			else if (scienceReports.Count > 0)
 			{
-				if (experimentLimit != 0)
+				if (experimentLimit != 0 && anim2 != null)
 				{
 					if (!string.IsNullOrEmpty(sampleAnim))
 						secondaryAnimator(sampleAnim, animSpeed, experimentNumber * (1f / experimentLimit), anim2[sampleAnim].length / experimentLimit);
@@ -1289,7 +1293,7 @@ namespace DMagic.Part_Modules
 			IScienceDataTransmitter bestTransmitter = ScienceUtil.GetBestTransmitter(vessel);
 			if (bestTransmitter != null)
 			{
-				if (experimentLimit != 0)
+				if (experimentLimit != 0 && anim2 != null)
 				{
 					if (!string.IsNullOrEmpty(sampleAnim))
 						secondaryAnimator(sampleAnim, animSpeed, experimentNumber * (1f / experimentLimit), anim2[sampleAnim].length / experimentLimit);
@@ -1315,7 +1319,7 @@ namespace DMagic.Part_Modules
 
 			if (labSearch.NextLabForDataFound)
 			{
-				if (experimentLimit != 0)
+				if (experimentLimit != 0 && anim2 != null)
 				{
 					if (!string.IsNullOrEmpty(sampleAnim))
 						secondaryAnimator(sampleAnim, animSpeed, experimentNumber * (1f / experimentLimit), anim2[sampleAnim].length / experimentLimit);
@@ -1440,7 +1444,7 @@ namespace DMagic.Part_Modules
 			}
 			else if (scienceReports.Contains(data))
 			{
-				if (experimentLimit != 0)
+				if (experimentLimit != 0 && anim2 != null)
 				{
 					if (!string.IsNullOrEmpty(sampleAnim))
 						secondaryAnimator(sampleAnim, animSpeed, experimentNumber * (1f / experimentLimit), anim2[sampleAnim].length / experimentLimit);

--- a/Source/Part Modules/DMModuleScienceAnimate.cs
+++ b/Source/Part Modules/DMModuleScienceAnimate.cs
@@ -1016,7 +1016,6 @@ namespace DMagic.Part_Modules
 			}
 			else if ((sitMask & (int)getSituation()) == 0)
 			{
-				MonoBehaviour.print("[XXX 1] sitMask " + sitMask + " situation " + (int)getSituation());
 				failMessage = customFailMessage;
 				return false;
 			}
@@ -1028,7 +1027,6 @@ namespace DMagic.Part_Modules
 			}
 			else if (scienceExp.requireAtmosphere && !vessel.mainBody.atmosphere)
 			{
-				MonoBehaviour.print("[XXX 2] reqatmo " + scienceExp.requireAtmosphere + " inatmo " + vessel.mainBody.atmosphere);
 				failMessage = customFailMessage;
 				return false;
 			}

--- a/Source/Part Modules/DMReconScope.cs
+++ b/Source/Part Modules/DMReconScope.cs
@@ -61,8 +61,7 @@ namespace DMagic.Part_Modules
 				bioMask = sitMask;
 			}
 
-			if (!string.IsNullOrEmpty(loopingAnimName))
-				loopingAnim = part.FindModelAnimators(loopingAnimName)[0];
+			loopingAnim = DMUtils.GetAnimation(part, loopingAnimName);
 
 			if (IsDeployed)
 				startLoopingAnimation(1f);

--- a/Source/Part Modules/DMSeismicHammer.cs
+++ b/Source/Part Modules/DMSeismicHammer.cs
@@ -72,8 +72,7 @@ namespace DMagic.Part_Modules
 
 		public override void OnStart(PartModule.StartState state)
 		{
-			if (!string.IsNullOrEmpty(hammerAnimation))
-				Anim = part.FindModelAnimators(hammerAnimation)[0];
+			Anim = DMUtils.GetAnimation(part, hammerAnimation);
 			RotationTransform = part.FindModelTransform(rotationTransformName);
 			ExtensionTransform = part.FindModelTransform(extensionTransformName);
 			modelTransform = part.transform.GetChild(0).GetChild(0);

--- a/Source/Part Modules/DMSolarCollector.cs
+++ b/Source/Part Modules/DMSolarCollector.cs
@@ -42,8 +42,7 @@ namespace DMagic.Part_Modules
 		public override void OnStart(PartModule.StartState state)
 		{
 			base.OnStart(state);
-			if (string.IsNullOrEmpty(loopingAnim))
-				anim = part.FindModelAnimators(loopingAnim)[0];
+			anim = DMUtils.GetAnimation(part, loopingAnim);
 			if (IsDeployed)
 				primaryAnimator(1f, 0f, WrapMode.Loop, loopingAnim, anim);
 		}


### PR DESCRIPTION
The universal storage modules seem to be missing some animations, which orbital science takes for granted are there. This caused the part initialization to crash. With this fix, will no longer crash but write a warning to the KSP log instead.

This doesn't fix misssing animations, but makes the code a bit more robust - and universal storage is back in business.